### PR TITLE
Make node tests run

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -932,12 +932,6 @@
       "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
       "dev": true
     },
-    "is-wsl": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
-      "dev": true
-    },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -3923,15 +3917,6 @@
         "wrappy": "1"
       }
     },
-    "opn": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/opn/-/opn-5.4.0.tgz",
-      "integrity": "sha512-YF9MNdVy/0qvJvDtunAOzFw9iasOQHpVthTCvGzxt61Il64AYSGdK+rYwld7NAfk9qJ7dt+hymBNSc9LNYS+Sw==",
-      "dev": true,
-      "requires": {
-        "is-wsl": "^1.1.0"
-      }
-    },
     "parse-glob": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
@@ -4250,26 +4235,6 @@
         "uglify-js": "^3.4.9"
       }
     },
-    "rollup-plugin-visualizer": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-0.9.2.tgz",
-      "integrity": "sha512-EHXHLp9Q8v5QdRTSjgio4Alr2MKxCJroLhJunmcH+pWAM5869nI5mdWjk2jp64rjxzEahrMYmfF/G5sbTHIhKw==",
-      "dev": true,
-      "requires": {
-        "mkdirp": "^0.5.1",
-        "opn": "^5.3.0",
-        "source-map": "^0.7.3",
-        "typeface-oswald": "0.0.54"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.7.3",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-          "dev": true
-        }
-      }
-    },
     "rollup-pluginutils": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.3.3.tgz",
@@ -4360,7 +4325,7 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
@@ -4508,12 +4473,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true
-    },
-    "typeface-oswald": {
-      "version": "0.0.54",
-      "resolved": "https://registry.npmjs.org/typeface-oswald/-/typeface-oswald-0.0.54.tgz",
-      "integrity": "sha512-U1WMNp4qfy4/3khIfHMVAIKnNu941MXUfs3+H9R8PFgnoz42Hh9pboSFztWr86zut0eXC8byalmVhfkiKON/8Q==",
       "dev": true
     },
     "typescript": {

--- a/package.json
+++ b/package.json
@@ -68,8 +68,9 @@
     "build": "npm run tslint && tsc -p . && rollup -c",
     "build-browser": "tsc -p . && cross-env ONLY_BROWSER=true rollup -c",
     "build-node": "tsc -p . && cross-env ONLY_NODE=true rollup -c",
+    "build-test": "tsc -p . && cross-env ONLY_NODE=true rollup -c rollup.test.config.js",
     "test": "npm run build",
-    "unit": "nyc --reporter=lcov --reporter=text-lcov mocha -r ts-node/register -t 50000 test/**/*.spec.ts",
+    "unit": "nyc --reporter=lcov --reporter=text-lcov mocha -t 5000 test-dist/index.js",
     "prepack": "npm i && npm run build"
   }
 }

--- a/rollup.test.config.js
+++ b/rollup.test.config.js
@@ -1,3 +1,3 @@
 import * as base from "./rollup.base.config";
 
-export default [base.nodeConfig(true), base.browserConfig(true)];
+export default [base.nodeConfig(true) /*, base.browserConfig(true)*/];

--- a/test/batchReceiver.spec.ts
+++ b/test/batchReceiver.spec.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import "mocha";
 import chai from "chai";
 const should = chai.should();
 import chaiAsPromised from "chai-as-promised";

--- a/test/namespace.spec.ts
+++ b/test/namespace.spec.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import "mocha";
 import chai from "chai";
 const should = chai.should();
 import chaiAsPromised from "chai-as-promised";

--- a/test/send.spec.ts
+++ b/test/send.spec.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import "mocha";
 import chai from "chai";
 const should = chai.should();
 import chaiAsPromised from "chai-as-promised";

--- a/test/streamingReceiver.spec.ts
+++ b/test/streamingReceiver.spec.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import "mocha";
 import chai from "chai";
 const should = chai.should();
 import chaiAsPromised from "chai-as-promised";


### PR DESCRIPTION
Makes node tests run by removing explicit import of `mocha` (this is not needed).